### PR TITLE
Fix path to java linter

### DIFF
--- a/lang/java.go
+++ b/lang/java.go
@@ -28,7 +28,7 @@ func LintJava(w http.ResponseWriter, r *http.Request, req handlers.LintRequest) 
 	var messages []string
 
 	// Reformat source code with google-java-format.
-	reformatted, err := Execute("/usr/lib/jvm/java-17-openjdk/bin/java", "-jar", "google-java-format-1.15.0-all-deps.jar", tempfile)
+	reformatted, err := Execute("/usr/lib/jvm/java-17-openjdk/bin/java", "-jar", "/home/op/google-java-format-1.24.0-all-deps.jar", tempfile)
 	if err != nil {
 		messages = append(messages, fmt.Sprintf("Reformat failed: %v", err))
 	}


### PR DESCRIPTION
Eu encontrei um erro relacionado a versão do java, que está como 1.15 e a versão utilizada é a 1.24. Segue a imagem do que peguei no docker localmente
<img width="963" alt="Screenshot 2025-05-10 at 09 21 11" src="https://github.com/user-attachments/assets/dcb68d0b-d9a7-4104-9f56-2094d6303dc8" />


Eu fiz a correção aqui e está rodando localmente aqui no docker:

https://github.com/user-attachments/assets/ed30ce84-3804-44d9-beed-b2e5ff041fb1

